### PR TITLE
Re-define now missing rebar.hrl logging macro's

### DIFF
--- a/src/rebar_proper_plugin.erl
+++ b/src/rebar_proper_plugin.erl
@@ -2,7 +2,6 @@
 -module(rebar_proper_plugin).
 -export([proper/2]).
 
--include_lib("rebar/include/rebar.hrl").
 -define(PROPER_DIR, ".proper").
 
 %% +-----------------------------------------------------------------+
@@ -10,6 +9,14 @@
 %% +-----------------------------------------------------------------+
 proper(Config, _AppFile) ->
     run_proper(Config, proper_opts(Config), proper_check_spec(Config)).
+
+%% +-----------------------------------------------------------------+
+%% | LOGGING MACROS                                                  |
+%% +-----------------------------------------------------------------+
+
+-define(DEBUG(Str, Args), rebar_log:log(debug, Str, Args)).
+-define(CONSOLE(Str, Args), io:format(Str, Args)).
+-define(ABORT(Str, Args), rebar_utils:abort(Str, Args)).
 
 %% +-----------------------------------------------------------------+
 %% | PRIVATE FUNCTIONS                                               |


### PR DESCRIPTION
As of this recent pull-request to rebar/rebar:
https://github.com/rebar/rebar/pull/281,
rebar/include/rebar.hrl no longer exists.

Since this project doesn't depend on any particular
version of rebar, and doesn't build with the
latest version from master, I have
reimplemented the logging macros that were previously
taken from the include file in the source itself.
